### PR TITLE
Added more migration documentation about advanced usage of anvil_extras routing

### DIFF
--- a/docs/migrating/index.md
+++ b/docs/migrating/index.md
@@ -89,7 +89,7 @@ NavLinks provide several advantages:
 
 ### `on_navigation` callback
 
-In hash routing the `on_navigation` method is called on the Template form when the hash changes. This is often used to update the active nav link in the sidebar. If you are using `Link` components in your sidebar, we recommend replacing these with `NavLink` components (see previous section). The `NavLink` component will automatically update the `active` property when the url changes, and removes the need for `click` handlers. `NavLink`s also improve user experience as they support `ctrl+click` to open in a new tab, and preserves the browser's native link preview behavior, allowing users to see the destination URL in their browser's status bar when hovering over the link.
+In hash routing the `on_navigation` method is called on the Template form when the hash changes. This is often used to update the active nav link in the sidebar. If you are using `Link` components in your sidebar, we recommend replacing these with `NavLink` components (see previous section).
 
 If you want to keep your existing `on_navigation` method, you can achieve this through the `router`'s event system. The `router` will emit a `navigation` event when the url changes.
 

--- a/docs/migrating/index.md
+++ b/docs/migrating/index.md
@@ -63,7 +63,7 @@ BaseRoute.template_container_properties = {"full_width_row": True}
 
 ### Navigation Links
 
-Replace regular HTML links with `NavLink` components. Instead of using click handlers and manually managing navigation, configure the path directly on the component:
+Replace regular HTML links with `NavLink` components. Instead of using click handlers and manually managing navigation, configure the path directly on the component (either in code or in the designer):
 
 ```python
 

--- a/docs/migrating/index.md
+++ b/docs/migrating/index.md
@@ -28,7 +28,7 @@ class IndexRoute(BaseRoute):
 
 If you have a single template in your hash routing app, then set `BaseRoute.template = "MyTemplate"`.
 
-If you have multiple templates, then you can set the `template` attribute on individual routes.
+If you have multiple templates, then you can set the `template` attribute on individual routes. See the section below that elaborates on how to work with multiple templates.
 
 ### `set_url_hash`
 
@@ -61,9 +61,35 @@ BaseRoute.template_container_properties = {"full_width_row": True}
 
 ```
 
+### Navigation Links
+
+Replace regular HTML links with `NavLink` components. Instead of using click handlers and manually managing navigation, configure the path directly on the component:
+
+```python
+
+from ._anvil_designer import MainTemplate
+from routing import router
+
+
+class Main(MainTemplate):
+    def __init__(self, **properties):
+        self.nav_home.path = '/home'
+        self.nav_settings.path = '/settings'
+        self.init_components(**properties)
+
+```
+
+NavLinks provide several advantages:
+- Automatic active state management
+- Support for ctrl+click to open in new tab
+- Native browser link preview behavior
+- No need for click handlers
+- Improved accessibility
+
+
 ### `on_navigation` callback
 
-In hash routing the `on_navigation` method is called on the Template form when the hash changes. This is often used to update the active nav link in the sidebar. If you are using `Link` components in your sidebar, we recommend replacing these with `NavLink` components. The `NavLink` component will automatically update the `active` property when the url changes, and removes the need for `click` handlers. `NavLink`s also improve user experience as they support `ctrl+click` to open in a new tab, and preserves the browser's native link preview behavior, allowing users to see the destination URL in their browser's status bar when hovering over the link.
+In hash routing the `on_navigation` method is called on the Template form when the hash changes. This is often used to update the active nav link in the sidebar. If you are using `Link` components in your sidebar, we recommend replacing these with `NavLink` components (see previous section). The `NavLink` component will automatically update the `active` property when the url changes, and removes the need for `click` handlers. `NavLink`s also improve user experience as they support `ctrl+click` to open in a new tab, and preserves the browser's native link preview behavior, allowing users to see the destination URL in their browser's status bar when hovering over the link.
 
 If you want to keep your existing `on_navigation` method, you can achieve this through the `router`'s event system. The `router` will emit a `navigation` event when the url changes.
 
@@ -102,3 +128,67 @@ class Main(MainTemplate):
 ```
 
 If you have multiple Templates, we recommend subscribing to the `navigation` event in the `form_show` method of your template form, and unsubscribing in the `form_hide` method. If you only have a single template, you can subscribe to the `navigation` event in the `__init__` method of your template form and there is no need to unsubscribe.
+
+### Using Different Templates, redirects, and other advanced usage
+
+When migrating from anvil_extras, you might have different templates for different parts of your application. For example, you might have:
+- A main template with navigation for authenticated users
+- A minimal template for authentication pages
+- A specialized template for admin sections
+
+You can configure this by setting different templates for different routes. You can also configure redirects and caching settings within each route class. Below is an example with two templates - one for authentication and one for the main app.
+
+```python
+
+from routing.router import TemplateWithContainerRoute as BaseRoute
+from routing.router import Redirect
+from .Global import Global  # if you have a module for global (cached) variables
+
+
+class EnsureUserMixin:
+    def before_load(self, **loader_args):
+        # Runs this method before loading the route form.
+        if not Global.user:
+            # Redirect if there is no logged in user.
+            raise Redirect(path="/signin")
+
+
+class SigninRoute(BaseRoute):
+    template = 'Templates.Static'  # Template for auth screen
+    path = '/signin'
+    form = 'Pages.Signin'
+    cache_form = True  # Cache settings for this route form.
+
+
+class SignupRoute(BaseRoute):
+    template = 'Templates.Static'  # Template for auth screen
+    path = '/signup'
+    form = 'Pages.Signup'
+    cache_form = True
+
+
+class HomeRoute(EnsureUserMixin, BaseRoute):
+    # This route and ones below inherits from two classes,
+    # which propagates the redirect from EnsureUserMixin
+    template = 'Templates.Router' # Main template for app
+    path = '/app/home'
+    form = 'Pages.Home'
+    cache_form = True
+
+
+class SettingsRoute(EnsureUserMixin, BaseRoute):
+    template = 'Templates.Router'
+    path = '/app/settings'
+    form = 'Pages.Settings'
+    cache_form = True
+
+
+class AdminRoute(EnsureUserMixin, BaseRoute):
+    template = 'Templates.Router'
+    path = '/app/admin'
+    form = 'Pages.Admin'
+    cache_form = True
+
+```
+
+Note that redirects are no longer defined in the startup form, but the routes module. In addition, caching is defined for each route, not as a parameter in the navigation function (anvil_extras set_url_hash).

--- a/docs/migrating/index.md
+++ b/docs/migrating/index.md
@@ -129,7 +129,7 @@ class Main(MainTemplate):
 
 If you have multiple Templates, we recommend subscribing to the `navigation` event in the `form_show` method of your template form, and unsubscribing in the `form_hide` method. If you only have a single template, you can subscribe to the `navigation` event in the `__init__` method of your template form and there is no need to unsubscribe.
 
-### Using Different Templates, redirects, and other advanced usage
+### Using multiple templates, redirects, and other advanced usage
 
 When migrating from anvil_extras, you might have different templates for different parts of your application. For example, you might have:
 - A main template with navigation for authenticated users

--- a/docs/migrating/index.md
+++ b/docs/migrating/index.md
@@ -191,4 +191,4 @@ class AdminRoute(EnsureUserMixin, BaseRoute):
 
 ```
 
-Note that redirects are no longer defined in the startup form, but the routes module. In addition, caching is defined for each route, not as a parameter in the navigation function (anvil_extras set_url_hash).
+Note that redirects are no longer defined in the startup form, but the routes module. In addition, caching is defined for each route, not as a parameter in the navigation function (anvil_extras `set_url_hash`). Any common attributes and methods can be set on base classes or mix-in classes.


### PR DESCRIPTION
I added some content about using multiple templates, how redirects are now defined, caching, and inheriting from multiple classes as a way to add bulk settings to multiple forms.