### PR TITLE
Correct attribute name

### DIFF
--- a/server_code/_special_routes.py
+++ b/server_code/_special_routes.py
@@ -25,7 +25,7 @@ def site_map_iter():
     yield from (
         f"{origin}{route.path}"
         for route in router.sorted_routes
-        if not route.private and route.path
+        if not route.sitemap and route.path
     )
 
 


### PR DESCRIPTION
`site_map_iter()` was using the original `private` Route attribute which has since changed to `sitemap`.