### PR TITLE
Fix docs use of `loader_args` in `load_data`

### DIFF
--- a/docs/data-loading/index.md
+++ b/docs/data-loading/index.md
@@ -65,7 +65,7 @@ class ArticleRoute(Route):
     form = "Pages.Article"
 
     def load_data(self, **loader_args):
-        row = loader_args.nav_context.get("row")
+        row = loader_args["nav_context"].get("row")
         if row is None:
             id = loader_args["path_params"]["id"]
             row = anvil.server.call("get_row", id)


### PR DESCRIPTION
`nav_context` is a part of the `loader_args` dict and can not be access as an attribute as documented.